### PR TITLE
Fix hot reloading by specifying explicit websocket address

### DIFF
--- a/.webpack/webpack.config.dev.js
+++ b/.webpack/webpack.config.dev.js
@@ -10,6 +10,9 @@ module.exports = choosePort( 9090 ).then( ( port ) => {
 	return presets.development( {
         name: 'datavis-block',
 		devServer: {
+			client: {
+				webSocketURL: `ws://localhost:${ port }/ws`,
+			},
 			port,
 			// Reduce watcher overhead and prevent PHP changes from triggering rebuild.
 			watchOptions: {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@humanmade/eslint-config": "^1.1.3",
-    "@humanmade/webpack-helpers": "^1.0.0-beta.10",
+    "@humanmade/webpack-helpers": "^1.0.0-beta.12",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.32.0",
     "eslint-config-react-app": "^3.0.8",


### PR DESCRIPTION
We've observed that the socket keeps trying to connect off of the local domain, rather than the server address where webpack is running. Specifying the websocket address manually instructs webpack to go directly to the localhost socket, rather than getting tied up in whatever local environment this is running within.

Also bumps Webpack Helpers 2 beta versions to pull in a slightly more stable filtering API, if ever needed.