### PR TITLE
Error when running outside of Node 16 or later

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Fail on incorrect Node version.
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "description": "A general-purpose WordPress data visualization block using the Vega visualization grammar",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "main": "index.js",
   "author": "Human Made",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
This will make it easier to diagnose when something fails because of inconsistent node versions.