### PR TITLE
Fix #12 and prevent infinite dataset XHR requests

### DIFF
--- a/src/components/DatasetEditor/dataset-editor.scss
+++ b/src/components/DatasetEditor/dataset-editor.scss
@@ -17,3 +17,8 @@
 .dataset-control-button {
 	height: 30px;
 }
+
+.dataset-form-error {
+	font-size: 0.9rem;
+	color: #cc1818;
+}

--- a/src/components/DatasetEditor/index.js
+++ b/src/components/DatasetEditor/index.js
@@ -221,7 +221,8 @@ const DatasetEditor = ( { json, setAttributes } ) => {
 				filename: selectedDataset,
 			}, { id: postId } ).then( updateDatasets );
 		}
-	}, [ selectedDataset, updateDatasets, postId ] );
+		setSelectedDataset( INLINE );
+	}, [ selectedDataset, updateDatasets, setSelectedDataset, postId ] );
 
 	return (
 		<div>

--- a/src/components/DatasetEditor/index.js
+++ b/src/components/DatasetEditor/index.js
@@ -170,7 +170,7 @@ const DatasetEditor = ( { json, setAttributes } ) => {
 	}, [ postId, json?.data?.url ] );
 
 	useEffect( () => {
-		if ( ! datasets.length ) {
+		if ( datasets === defaultDatasets ) {
 			updateDatasets();
 		}
 	}, [ datasets, updateDatasets ] );
@@ -251,7 +251,7 @@ const DatasetEditor = ( { json, setAttributes } ) => {
 						className="dataset-control-button is-primary"
 						onClick={ () => setIsAddingNewDataset( true ) }
 					>
-						{ __( 'New', 'datavis' ) }
+						{ __( 'New dataset', 'datavis' ) }
 					</Button>
 				</PanelRow>
 			) }


### PR DESCRIPTION
When the datasets array was empty, it would continually request datasets even if it already got (empty) results from the API.

There was also an issue as described in #12 where deleting a dataset would continue to show the stale data from the removed dataset.

While we need to eventually refactor the dataset handling entirely to fix some edge cases (#10), this PR resolves some of the immediate issues.

Also rearranges code to group the dataset editor and its css in one directory.