### PR TITLE
Expose CSV as JSON on request, and add PHPCS to project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         "humanmade/coding-standards": "^1.1.0"
     },
     "scripts": {
-        "lint": "phpcs --standard=vendor/humanmade/coding-standards .",
-        "lint:fix": "phpcbf --standard=vendor/humanmade/coding-standards ."
-    },
+        "lint": "phpcs plugin.php inc",
+        "lint:fix": "phpcbf plugin.php inc"
+	},
     "config": {
         "allow-plugins": {
             "composer/installers": true,

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "humanmade/datavis-block",
+    "description": "Flexible data visualization using Vega Lite and per-post dataset management.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "composer/installers": "~1.0"
+    },
+    "require-dev": {
+        "humanmade/coding-standards": "^1.1.0"
+    },
+    "scripts": {
+        "lint": "phpcs --standard=vendor/humanmade/coding-standards .",
+        "lint:fix": "phpcbf --standard=vendor/humanmade/coding-standards ."
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -24,7 +24,7 @@ function register_blocks() : void {
 				'json' => [
 					'type'    => 'object',
 					'default' => [],
-				]
+				],
 			],
 		]
 	);
@@ -33,7 +33,7 @@ function register_blocks() : void {
 /**
  * Render function for block.
  *
- * @param array $attributes
+ * @param array $attributes Block attributes.
  *
  * @return string
  */

--- a/inc/datasets/endpoints.php
+++ b/inc/datasets/endpoints.php
@@ -6,16 +6,11 @@
 namespace Datavis_Block\Datasets\Endpoints;
 
 use Datavis_Block\Datasets;
+
 use Datavis_Block\Datasets\Metadata;
-
-use WP_REST_Request;
-use WP_REST_Response;
-use WP_REST_Server;
 use WP_Error;
-
-use function Datavis_Block\Datasets\Metadata\get_dataset;
-
-use const Datavis_Block\Datasets\Metadata\META_KEY;
+use WP_REST_Request;
+use WP_REST_Server;
 
 function bootstrap() : void {
 	add_action( 'rest_api_init', __NAMESPACE__ . '\\register_dataset_routes' );
@@ -33,7 +28,7 @@ function get_dataset_schema() : array {
 			'description' => __( 'Filename to use for the dataset.', 'datavis' ),
 			'type'        => 'string',
 			'default'     => 'data.csv',
-			'required'    => true
+			'required'    => true,
 		],
 		'content' => [
 			'description' => __( 'CSV file contents as string.', 'datavis' ),

--- a/inc/datasets/endpoints.php
+++ b/inc/datasets/endpoints.php
@@ -12,6 +12,9 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 
+/**
+ * Connect namespace functions to actions and hooks.
+ */
 function bootstrap() : void {
 	add_action( 'rest_api_init', __NAMESPACE__ . '\\register_dataset_routes' );
 	add_action( 'rest_pre_serve_request', __NAMESPACE__ . '\\deliver_dataset_as_csv', 10, 4 );
@@ -240,6 +243,12 @@ function get_dataset_item( WP_REST_Request $request ) {
 	return rest_ensure_response( $dataset );
 }
 
+/**
+ * Delete a single dataset item.
+ *
+ * @param WP_REST_Request $request Full details about the request.
+ * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+ */
 function delete_dataset_item( WP_REST_Request $request ) {
 	$post_id = $request['post_id'];
 
@@ -285,6 +294,8 @@ function deliver_dataset_as_csv( $served, $result, $request, $server ) {
 
 	if ( $request['format'] === 'json' ) {
 		$json = Datasets\csv_to_json( $csv_data['content'] );
+		// TODO: Is there a security implication here, or a proper way to escape this?
+		// phpcs:ignore
 		echo wp_json_encode( $json );
 		return true;
 	}

--- a/inc/datasets/endpoints.php
+++ b/inc/datasets/endpoints.php
@@ -276,7 +276,7 @@ function delete_dataset_item( WP_REST_Request $request ) {
  * @return true
  */
 function deliver_dataset_as_csv( $served, $result, $request, $server ) {
-	if ( $request['format'] !== 'csv' || strpos( $request->get_route(), '/datasets/' ) === false || $request->get_method() !== 'GET' ) {
+	if ( strpos( $request->get_route(), '/datasets/' ) === false || $request->get_method() !== 'GET' ) {
 		return $served;
 	}
 
@@ -286,6 +286,12 @@ function deliver_dataset_as_csv( $served, $result, $request, $server ) {
 		// This may not be a CSV metadata object response. For safety, do nothing.
 		// Note that empty "content" is acceptable, but the property must exist.
 		return $served;
+	}
+
+	if ( $request['format'] === 'json' ) {
+		$json = Datasets\csv_to_json( $csv_data['content'] );
+		echo wp_json_encode( $json );
+		return true;
 	}
 
 	if ( ! headers_sent() ) {

--- a/inc/datasets/metadata.php
+++ b/inc/datasets/metadata.php
@@ -102,12 +102,12 @@ function update_dataset( int $post_id, string $filename, string $content ) : boo
 	$meta_value = get_dataset_meta( $post_id );
 
 	$filename = strtolower( $filename );
-	if ( isset( $meta_value[$filename] ) && trim( $meta_value[$filename] ) === trim( $content ) ) {
+	if ( isset( $meta_value[ $filename ] ) && trim( $meta_value[ $filename ] ) === trim( $content ) ) {
 		// No update needed.
 		return true;
 	}
 
-	$meta_value[$filename] = $content;
+	$meta_value[ $filename ] = $content;
 
 	$updated = update_post_meta( $post_id, META_KEY, $meta_value );
 
@@ -125,12 +125,12 @@ function update_dataset( int $post_id, string $filename, string $content ) : boo
 function delete_dataset( int $post_id, string $filename ) : bool {
 	$meta_value = get_dataset_meta( $post_id );
 
-	if ( empty( $meta_value ) || ! isset( $meta_value[$filename] ) ) {
+	if ( empty( $meta_value ) || ! isset( $meta_value[ $filename ] ) ) {
 		// No dataset, cannot delete.
 		return false;
 	}
 
-	unset( $meta_value[$filename] );
+	unset( $meta_value[ $filename ] );
 
 	if ( empty( $meta_value ) ) {
 		// All datasets removed: delete wholesale.
@@ -147,9 +147,9 @@ function delete_dataset( int $post_id, string $filename ) : bool {
  * @return array Filtered metadata fields.
  */
 function do_not_index_dataset_meta( $meta ) {
-	foreach( $meta as $key => $value ) {
+	foreach ( $meta as $key => $value ) {
 		if ( preg_match( '/datasets/', $key ) ) {
-			unset( $meta[$key] );
+			unset( $meta[ $key ] );
 		}
 	}
 	return $meta;

--- a/inc/datasets/metadata.php
+++ b/inc/datasets/metadata.php
@@ -120,7 +120,7 @@ function update_dataset( int $post_id, string $filename, string $content ) : boo
  *
  * @param int    $post_id  ID of post for which to edit meta.
  * @param string $filename String filename of dataset to delete.
- * @param bool True on successful delete, false on failure.
+ * @return bool True on successful delete, false on failure.
  */
 function delete_dataset( int $post_id, string $filename ) : bool {
 	$meta_value = get_dataset_meta( $post_id );

--- a/inc/datasets/namespace.php
+++ b/inc/datasets/namespace.php
@@ -41,3 +41,31 @@ function get_supported_post_types() : array {
 		}
 	);
 }
+
+/**
+ * Convert a CSV dataset to a JSON object.
+ *
+ * @todo Is there a more robust existing solution to this problem?
+ *
+ * @param string $csv String CSV content.
+ * @return array Array of field details.
+ */
+function csv_to_json( string $csv ) : array {
+	/** @var array rows -- fix in-editor type hinting. */
+	$rows = array_map( 'str_getcsv', array_filter( explode( "\n", $csv ) ) );
+	$headers = $rows[0];
+	$data = array_slice( $rows, 1 );
+	return array_reduce(
+		$data,
+		function( $carry, $row ) use ( $headers ) {
+			$object = [];
+			foreach ( $headers as $idx => $field ) {
+				$value = $row[ $idx ];
+				$object[ $field ] = is_numeric( $value ) ? floatval( $value ) : $value;
+			}
+			$carry[] = $object;
+			return $carry;
+		},
+		[]
+	);
+}

--- a/inc/datasets/namespace.php
+++ b/inc/datasets/namespace.php
@@ -14,6 +14,9 @@ function bootstrap() : void {
 	add_action( 'init', __NAMESPACE__ . '\\register_dataset_post_type_support' );
 }
 
+/**
+ * Register the datasets post type supports value on the appropriate post types.
+ */
 function register_dataset_post_type_support() : void {
 	/**
 	 * Allow dataset support to be extended to additional post types beyond the defaults.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   ],
   "scripts": {
     "test": "jest",
-    "lint": "eslint src .eslintrc.js",
+    "lint": "npm run eslint; npm run phpcs",
+    "eslint": "eslint src .eslintrc.js",
+    "phpcs": "composer lint",
     "start": "webpack-dev-server --config=.webpack/webpack.config.dev.js",
     "build": "webpack --config=.webpack/webpack.config.prod.js"
   },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset>
+	<!-- Turn off rules which feel superfluous or distracting within test files. -->
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.ClassComment.Missing">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+		<exclude-pattern>tests/bootstrap.php</exclude-pattern>
+	</rule>
+</ruleset>


### PR DESCRIPTION
This PR bundles two completely unrelated pieces of functionality:

- Add PHPCS so we can enforce consistent coding standards in our PHP files
- Allow CSV endpoints to return the actual CSV content as a JSON array if `format=json`