### PR TITLE
Add release helper scripts

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -5,11 +5,13 @@ on:
       - 'main'
     paths:
       - '**.js'
+      - '**.json'
   pull_request:
     branches:
       - '**'
     paths:
       - '**.js'
+      - '**.json'
 
 jobs:
   build:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ steps.npm-cache-dir.outputs.node-version }}-${{ steps.npm-cache-dir.outputs.npm-version }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
 
       - name: Run the build
         run: |

--- a/.github/workflows/php-standards.yml
+++ b/.github/workflows/php-standards.yml
@@ -5,11 +5,13 @@ on:
       - 'main'
     paths:
       - '**.php'
+      - '**.json'
   pull_request:
     branches:
       - '**'
     paths:
       - '**.php'
+      - '**.json'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -46,11 +46,19 @@ Even when bumping a major version, if the blocks provided by this plugin change 
 
 ### Publishing a Release
 
-Release management is done using GitHub's built-in Releases functionality. Each release is tagged using the according version number, for example, the version 1.2.3 of this plugin would have the tag name `v1.2.3`.
-
-To generate a release, ensure the `main` branch is clean and up to date, and then tag it in the format `v#.#.#`.
-Once that tag is pushed, the GitHub actions release workflow creates a new built release based on the contents of the tag you just created.
-It will copy the tag's current state to a new tag of `original/v.*.*.*` and then build the project and push the built version to the original tag name `v*.*.*`.
+Release management is done using GitHub's built-in Releases functionality. When you tag a commit on the `main` branch with a version number in the format `v#.#.#`, a release action will trigger when that tag is pushed to GitHub.
+The GitHub actions release workflow creates a new built release based on the contents of the tag you created.
+It copies the tag's current state to a new tag of `original/v.*.*.*`, then builds the project and pushes the built version to the original tag name `v*.*.*`.
 This allows composer to pull in a built version of the project without the need to run webpack to use it.
+
+To prepare a release, follow these steps:
+
+0. Ensure you are on the `main` branch and that there are no uncommitted local changes.
+1. Depending on whether you are preparing a major, minor, or patch release (see [Versioning](#versioning) above), run one of these three NPM actions to update the version number throughout the project:
+  - `npm run bump:patch`: Update the project's version number to the next patch release number.
+  - `npm run bump:minor`: Update the project's version number to the next minor release number.
+  - `npm run bump:major`: Update the project's version number to the next major release number.
+2. Create a tag with the same number as the updated project version number, e.g. `v1.2.3`.
+3. Push the updated `main` branch and tag to GitHub.
 
 Once a release has been created, update the release's description using GitHub's interface to add patch notes. Release notes should be high-level but complete, detailing all _New Features_, _Enhancements_, _Bug Fixes_ and potential other changes included in the according version.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Datavis Block
 
+Stable tag: 0.0.1
+
 This plugin provides a flexible data visualization block using the [Vega-Lite](https://vega.github.io/) declarative JSON visualization grammar.
 
 - [Getting Started with Vega-Lite](https://vega.github.io/vega-lite/tutorials/getting_started.html)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "eslint": "eslint src .eslintrc.js",
     "phpcs": "composer lint",
     "start": "webpack-dev-server --config=.webpack/webpack.config.dev.js",
-    "build": "webpack --config=.webpack/webpack.config.prod.js"
+    "build": "webpack --config=.webpack/webpack.config.prod.js",
+    "bump:patch": "bump patch --commit 'Prepare v%s release' package.json README.md plugin.php",
+    "bump:minor": "bump minor --commit 'Prepare v%s release' package.json README.md plugin.php",
+    "bump:major": "bump major --commit 'Prepare v%s release' package.json README.md plugin.php"
   },
   "dependencies": {
     "ajv": "^8.11.0",
@@ -57,6 +60,7 @@
     "lodash.throttle": "^4.1.1",
     "react": "^17.0.2",
     "sass": "^1.52.1",
+    "version-bump-prompt": "^6.1.0",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.2"


### PR DESCRIPTION
- Add `version-bump-prompt` and associated NPM scripts
- Expand release process documentation
- Run PHP and JS tests when JSON configuration changes, in case package or composer dependencies or block.json files were updated